### PR TITLE
Give version argument of the QmlClass constructor a default value

### DIFF
--- a/doxyqml/qmlclass.py
+++ b/doxyqml/qmlclass.py
@@ -14,7 +14,7 @@ class QmlClass(object):
     SINGLETON_COMMENT = "/** @remark This component is a singleton */"
     VERSION_COMMENT = "/** @since %s */"
 
-    def __init__(self, name, version):
+    def __init__(self, name, version = None):
         self.name = name
         self.base_name = ""
         self.header_comments = []


### PR DESCRIPTION
This is the minimaly invasive change to make the unit tests work again.
