### PR TITLE
Fixed handling of white-space prefix on 'import'. Updated test case.

### DIFF
--- a/doxyqml/lexer.py
+++ b/doxyqml/lexer.py
@@ -39,7 +39,7 @@ class Lexer(object):
             Tokenizer(STRING, re.compile(r'("([^\\"]|(\\.))*")')),
             Tokenizer(BLOCK_START, re.compile("{")),
             Tokenizer(BLOCK_END, re.compile("}")),
-            Tokenizer(IMPORT, re.compile("^import\s+.*$", re.MULTILINE)),
+            Tokenizer(IMPORT, re.compile("import\s+.*$", re.MULTILINE)),
             Tokenizer(PRAGMA, re.compile("^pragma\s+\w.*$", re.MULTILINE)),
             Tokenizer(KEYWORD, re.compile("(default\s+property|property|readonly\s+property|signal)\s+")),
             Tokenizer(KEYWORD, re.compile("(function)\s+[^(]")),  # a named function

--- a/tests/functional/relative-import/input/RelativeImport.qml
+++ b/tests/functional/relative-import/input/RelativeImport.qml
@@ -1,6 +1,6 @@
 import QtQuick 2.0
 import QtQuick.Controls 1.0
-import QtQuick.Controls.Styles 1.0
+ import QtQuick.Controls.Styles 1.0
 import  "."
 import "qrc:///something"
 


### PR DESCRIPTION
These changes are to address issue-35. I am not sure if my changes in lexer.py are ideal, but they work. I was trying to get the regular expression on line 42 to be "^\s*import\s+.*$", but that didn't work. I am not sure why. Removing the "^" before "import" worked, though. It may not be most elegant, but I could get the functional tests to pass.