### PR TITLE
Fix for paths for relative imports, issue #32

### DIFF
--- a/doxyqml/doxyqml.py
+++ b/doxyqml/doxyqml.py
@@ -6,10 +6,12 @@ import os
 import re
 import sys
 
-doxyqml_path = os.path.join(os.path.dirname(__file__), os.pardir, os.pardir)
-sys.path.append(doxyqml_path)
+# On some systems (e.g., Windows 10 with Python 3.6.5), relative imports
+# (e.g., from . import qmlparser) are not allowed. Therefore, insert the
+# path to doxyqml package in PYTHONPATH, so that imports are possible.
+doxyqmlPackage_path = os.path.join(os.path.dirname(__file__), os.pardir)
+sys.path.insert(0, doxyqmlPackage_path)
 
-import doxyqml
 import qmlparser
 from lexer import Lexer, LexerError
 from qmlclass import QmlClass

--- a/doxyqml/doxyqml.py
+++ b/doxyqml/doxyqml.py
@@ -6,9 +6,13 @@ import os
 import re
 import sys
 
-from . import qmlparser
-from .lexer import Lexer, LexerError
-from .qmlclass import QmlClass
+doxyqml_path = os.path.join(os.path.dirname(__file__), os.pardir, os.pardir)
+sys.path.append(doxyqml_path)
+
+import doxyqml
+import qmlparser
+from lexer import Lexer, LexerError
+from qmlclass import QmlClass
 
 
 VERSION = "0.4.0"

--- a/doxyqml/qmlparser.py
+++ b/doxyqml/qmlparser.py
@@ -1,7 +1,12 @@
-import lexer
+import os
+import sys
 
-from qmlclass import QmlArgument, QmlProperty, QmlFunction, QmlSignal
+# See comment in doxyqml.py on why the following path change is needed
+doxyqmlPackage_path = os.path.join(os.path.dirname(__file__), os.pardir)
+sys.path.insert(0, doxyqmlPackage_path)
 
+from doxyqml import lexer
+from doxyqml.qmlclass import QmlArgument, QmlProperty,  QmlSignal, QmlFunction
 
 class QmlParserError(Exception):
     def __init__(self, msg, token):

--- a/doxyqml/qmlparser.py
+++ b/doxyqml/qmlparser.py
@@ -1,6 +1,6 @@
-from . import lexer
+import lexer
 
-from .qmlclass import QmlArgument, QmlProperty, QmlFunction, QmlSignal
+from qmlclass import QmlArgument, QmlProperty, QmlFunction, QmlSignal
 
 
 class QmlParserError(Exception):

--- a/tests/functional/tests.py
+++ b/tests/functional/tests.py
@@ -8,11 +8,6 @@ import shutil
 import sys
 import subprocess
 
-doxyqml_path = os.path.join(os.path.dirname(__file__), os.pardir, os.pardir)
-sys.path.insert(0, doxyqml_path)
-
-from doxyqml import doxyqml
-
 
 def list_files(topdir):
     result = []
@@ -121,7 +116,7 @@ class Test(object):
 def main():
     script_dir = os.path.dirname(__file__) or "."
 
-    default_doxyqml = os.path.abspath(os.path.join(script_dir, os.pardir, os.pardir, "bin", "doxyqml"))
+    default_doxyqml = os.path.abspath(os.path.join(script_dir, os.pardir, os.pardir, "doxyqml", "doxyqml.py"))
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-u", "--update",

--- a/tests/manual/Doxyfile
+++ b/tests/manual/Doxyfile
@@ -109,7 +109,12 @@ EXAMPLE_PATTERNS       =
 EXAMPLE_RECURSIVE      = NO
 IMAGE_PATH             =
 INPUT_FILTER           =
+
+
 FILTER_PATTERNS        = *.qml=doxyqml
+# Comment out the above one with the one below for Windows
+#FILTER_PATTERNS        = *.qml=C:\Python3\Lib\site-packages\doxyqml\doxyqml.py
+
 FILTER_SOURCE_FILES    = NO
 FILTER_SOURCE_PATTERNS =
 #---------------------------------------------------------------------------

--- a/tests/manual/Doxyfile.windows
+++ b/tests/manual/Doxyfile.windows
@@ -109,7 +109,7 @@ EXAMPLE_PATTERNS       =
 EXAMPLE_RECURSIVE      = NO
 IMAGE_PATH             =
 INPUT_FILTER           =
-FILTER_PATTERNS        = *.qml=doxyqml
+FILTER_PATTERNS        = *.qml=C:\Python3\Lib\site-packages\doxyqml\doxyqml.py
 FILTER_SOURCE_FILES    = NO
 FILTER_SOURCE_PATTERNS =
 #---------------------------------------------------------------------------

--- a/tests/manual/tests.py
+++ b/tests/manual/tests.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+
+import platform
+from subprocess import call
+
+def main():
+    doxyfileName = "Doxyfile"
+    if platform.system() == "Windows":
+        print ("Windows")
+        doxyfileName = "Doxyfile.windows"
+
+    call(["doxygen", doxyfileName])
+    
+    
+if __name__ == "__main__":
+    main()
+# vi: ts=4 sw=4 et

--- a/tests/unit/qmlparsertestcase.py
+++ b/tests/unit/qmlparsertestcase.py
@@ -16,10 +16,10 @@ class QmlParserTestCase(TestCase):
         self.assertEqual(qmlclass.base_name, "Item")
 
         functions = qmlclass.get_functions()
+        self.assertEqual(len(functions), 2)
         self.assertEqual(functions[0].name, "foo")
         self.assertEqual(functions[1].name, "bar")
-        self.assertEqual(len(functions), 2)
-
+ 
     def test_default_property(self):
         src = """Item {
             /// v1 doc
@@ -33,6 +33,7 @@ class QmlParserTestCase(TestCase):
         qmlparser.parse(lexer.tokens, qmlclass)
 
         properties = qmlclass.get_properties()
+        self.assertEqual(len(properties), 2)
         self.assertEqual(properties[0].name, "v1")
         self.assertEqual(properties[0].type, "int")
         self.assertEqual(properties[0].doc, "/// v1 doc")
@@ -56,6 +57,7 @@ class QmlParserTestCase(TestCase):
         qmlparser.parse(lexer.tokens, qmlclass)
 
         properties = qmlclass.get_properties()
+        self.assertEqual(len(properties), 2)
         self.assertEqual(properties[0].name, "v1")
         self.assertEqual(properties[0].type, "int")
         self.assertEqual(properties[0].doc, "/// v1 doc")
@@ -77,6 +79,7 @@ class QmlParserTestCase(TestCase):
         qmlparser.parse(lexer.tokens, qmlclass)
 
         properties = qmlclass.get_properties()
+        self.assertEqual(len(properties), 1)
         self.assertEqual(properties[0].name, "varProperty")
         self.assertEqual(properties[0].type, "var")
 
@@ -91,6 +94,7 @@ class QmlParserTestCase(TestCase):
         qmlparser.parse(lexer.tokens, qmlclass)
 
         properties = qmlclass.get_properties()
+        self.assertEqual(len(properties), 1)
         self.assertEqual(properties[0].name, "fnProperty")
         self.assertEqual(properties[0].type, "var")
 
@@ -108,6 +112,7 @@ class QmlParserTestCase(TestCase):
         qmlparser.parse(lexer.tokens, qmlclass)
 
         properties = qmlclass.get_properties()
+        self.assertEqual(len(properties), 1)
         self.assertEqual(properties[0].name, "prop2")
         self.assertEqual(properties[0].type, "string")
         self.assertEqual(properties[0].doc, "/// prop2 doc")
@@ -125,6 +130,7 @@ class QmlParserTestCase(TestCase):
         qmlparser.parse(lexer.tokens, qmlclass)
 
         functions = qmlclass.get_functions()
+        self.assertEqual(len(functions), 1)
         self.assertEqual(functions[0].name, "foo")
         self.assertEqual(functions[0].type, "void")
 
@@ -141,5 +147,6 @@ class QmlParserTestCase(TestCase):
         qmlparser.parse(lexer.tokens, qmlclass)
 
         functions = qmlclass.get_functions()
+        self.assertEqual(len(functions), 1)        
         self.assertEqual(functions[0].name, "foo")
         self.assertEqual(functions[0].type, "void")

--- a/tests/unit/tests.py
+++ b/tests/unit/tests.py
@@ -1,11 +1,6 @@
 #!/usr/bin/env python3
 
-import os
 import unittest
-import sys
-
-doxyqml_path = os.path.join(os.path.dirname(__file__), os.pardir, os.pardir)
-sys.path.insert(0, doxyqml_path)
 
 from qmlclasstestcase import *
 from qmlparsertestcase import *


### PR DESCRIPTION
I could reproduce the problems from issue #32 using the manual tests on my computer. I have a fix that works on Windows 10. Can someone please help test the changes on other Operating Systems?

The changes include tweaking of the paths, and a new tests.py in manual tests directory that switches the Doxyfile based on the system. 