### PR TITLE
Add basic support for inline (trailing) Doxygen comments

### DIFF
--- a/doxyqml/lexer.py
+++ b/doxyqml/lexer.py
@@ -105,11 +105,6 @@ class Lexer(object):
             # Try to move trailing comments ahead of their parent KEYWORD. This way they get properly
             #   handed over to the Qml* object type handlers which can do with them as they wish.
             if (t.type == ICOMMENT and i > 1):
-                # We could keep this as a ICOMMENT if it were useful down the line.
-                # But currently this info is not passed onto Qml* classes anyway so we'll need
-                #  to detect trailing comments via a regex when parsing the individual types.
-                # To avoid looking for 2 types of comments later in the code, just change it to COMMENT.
-                self.tokens[i] = Token(COMMENT, t.value, t.idx)
                 # Iterate backwards looking for a KEYWORD. As a sanity measure
                 #   we only search back up to 20 tokens or until an "invalid" token is found.
                 for ii, tt in enumerate(self.tokens[i-1 : max(i-20, 0) : -1]):
@@ -117,12 +112,13 @@ class Lexer(object):
                         ins_idx = i-ii-1
                         # Final sanity check for a misplaced inline comment, 
                         #   if previous token is another doxy comment then bail out.
-                        if (ins_idx > 0 and self.tokens[ins_idx-1].type == COMMENT and 
-                                plain_cmnt_rx.match(self.tokens[ins_idx-1].value) == None):
+                        if (ins_idx > 0 and 
+                                (self.tokens[ins_idx-1].type == ICOMMENT or 
+                                (self.tokens[ins_idx-1].type == COMMENT and plain_cmnt_rx.match(self.tokens[ins_idx-1].value) == None))):
                             break
                         self.tokens.insert(ins_idx, self.tokens.pop(i))
                         break
-                    if (tt.type in [COMMENT,IMPORT,PRAGMA]):
+                    if (tt.type in [COMMENT, ICOMMENT, IMPORT, PRAGMA]):
                         break
 
     def append_token(self, type, value):

--- a/doxyqml/qmlclass.py
+++ b/doxyqml/qmlclass.py
@@ -2,6 +2,7 @@ import logging
 import re
 
 TYPE_RX = "(?P<prefix>\s+type:)(?P<type>[\w.<>|]+)"
+INLINE_COMMENT_RX = re.compile("^/[/*][/!*]<")
 
 def post_process_type(rx, text, type):
     match = rx.search(text)
@@ -9,6 +10,9 @@ def post_process_type(rx, text, type):
         type = match.group("type")
         text = text[:match.start("prefix")] + text[match.end("type"):]
     return text, type
+
+def is_inline_comment(text):
+    return bool(INLINE_COMMENT_RX.match(text))
 
 class QmlClass(object):
     SINGLETON_COMMENT = "/** @remark This component is a singleton */"
@@ -107,16 +111,21 @@ class QmlProperty(object):
 
     def __str__(self):
         self.post_process_doc()
-        lst = [self.doc]
+        inline = is_inline_comment(self.doc)
+        lst = []
+        if not inline:
+            lst.append(self.doc + "\n")
+        if self.is_default:
+            lst.append(self.DEFAULT_PROPERTY_COMMENT + "\n")
+        elif self.is_readonly:
+            lst.append(self.READONLY_PROPERTY_COMMENT + "\n")
         lst.append("Q_PROPERTY(%s %s)" % (self.type, self.name))
-        return "\n".join(lst)
+        if inline:
+            lst.append(" " + self.doc)
+        return "".join(lst)
 
     def post_process_doc(self):
         self.doc, self.type = post_process_type(self.type_rx, self.doc, self.type)
-        if self.is_default:
-            self.doc = self.doc + "\n" + self.DEFAULT_PROPERTY_COMMENT
-        elif self.is_readonly:
-            self.doc = self.doc + "\n" + self.READONLY_PROPERTY_COMMENT
 
 
 class QmlFunction(object):
@@ -131,9 +140,14 @@ class QmlFunction(object):
     def __str__(self):
         self.post_process_doc()
         arg_string = ", ".join([str(x) for x in self.args])
-        lst = [self.doc]
+        inline = is_inline_comment(self.doc)
+        lst = []
+        if not inline:
+            lst.append(self.doc + "\n")
         lst.append("%s %s(%s);" % (self.type, self.name, arg_string))
-        return "\n".join(lst)
+        if inline:
+            lst.append(" " + self.doc)
+        return "".join(lst)
 
     def post_process_doc(self):
         def repl(match):
@@ -160,10 +174,16 @@ class QmlSignal(object):
 
     def __str__(self):
         arg_string = ", ".join([str(x) for x in self.args])
-        lst = [self.doc]
+        inline = is_inline_comment(self.doc)
+        lst = []
+        if not inline:
+            lst.append(self.doc + "\n")
         # This strange syntax makes it possible to declare a signal without
         # turning all functions defined after into signals.
         # It could be replaced with the use of Q_SIGNAL, but my version of
         # Doxygen (1.8.4) does not support it
-        lst.append("Q_SIGNALS: void %s(%s); public:" % (self.name, arg_string))
-        return "\n".join(lst)
+        lst.append("Q_SIGNALS: void %s(%s); " % (self.name, arg_string))
+        if inline:
+            lst.append(self.doc + "\n")
+        lst.append("public:")
+        return "".join(lst)

--- a/doxyqml/qmlparser.py
+++ b/doxyqml/qmlparser.py
@@ -18,25 +18,25 @@ def parse_class_definition(reader, cls):
     token = reader.consume_wo_comments()
     if token.type != lexer.BLOCK_START:
         raise QmlParserError("Expected '{' after base class name", token)
-    last_comment = None
+    last_comment_token = None
     while not reader.at_end():
         token = reader.consume()
-        if token.type == lexer.COMMENT:
-            if last_comment:
-                cls.add_element(last_comment)
-            last_comment = token.value
+        if is_comment_token(token):
+            if last_comment_token:
+                cls.add_element(last_comment_token.value)
+            last_comment_token = token
         elif token.type == lexer.KEYWORD:
-            done = parse_class_content(reader, cls, token, last_comment)
-            last_comment = None
+            done = parse_class_content(reader, cls, token, last_comment_token)
+            last_comment_token = None
         elif token.type == lexer.BLOCK_START:
             skip_block(reader)
         elif token.type == lexer.BLOCK_END:
             break
-    if last_comment:
-        cls.add_element(last_comment)
+    if last_comment_token:
+        cls.add_element(last_comment_token.value)
 
 
-def parse_class_content(reader, cls, token, doc):
+def parse_class_content(reader, cls, token, doc_token):
     keyword = token.value
     if keyword.endswith("property"):
         obj = parse_property(reader, keyword)
@@ -46,8 +46,9 @@ def parse_class_content(reader, cls, token, doc):
         obj = parse_signal(reader)
     else:
         raise QmlParserError("Unknown keyword '%s'" % keyword, token)
-    if doc is not None:
-        obj.doc = doc
+    if doc_token is not None:
+        obj.doc = doc_token.value
+        obj.doc_is_inline = (doc_token.type == lexer.ICOMMENT)
     cls.add_element(obj)
 
 
@@ -130,7 +131,7 @@ def skip_block(reader):
 def parse_header(reader, cls):
     while not reader.at_end():
         token = reader.consume()
-        if token.type == lexer.COMMENT:
+        if is_comment_token(token):
             cls.add_header_comment(token.value)
         elif token.type == lexer.IMPORT:
             cls.add_import(token.value)
@@ -145,11 +146,13 @@ def parse_header(reader, cls):
 def parse_footer(reader, cls):
     while not reader.at_end():
         token = reader.consume()
-        if token.type == lexer.COMMENT:
+        if is_comment_token(token):
             cls.add_footer_comment(token.value)
         else:
             raise QmlParserUnexpectedTokenError(token)
 
+def is_comment_token(token):
+    return (token.type in [lexer.COMMENT, lexer.ICOMMENT])
 
 class TokenReader(object):
     def __init__(self, tokens):
@@ -164,7 +167,7 @@ class TokenReader(object):
     def consume_wo_comments(self):
         while True:
             token = self.consume()
-            if token.type != lexer.COMMENT:
+            if not is_comment_token(token):
                 return token
 
     def consume_expecting(self, type, value=None):

--- a/tests/functional/basic/expected/InlineComments.qml.cpp
+++ b/tests/functional/basic/expected/InlineComments.qml.cpp
@@ -1,0 +1,40 @@
+using namespace QtQuick;
+/*
+ * Header bla
+ */
+///< What happens here?
+/**
+ * A very simple item   ///< How about here?
+ */
+class InlineComments : public Item {
+public:
+Q_PROPERTY(int foo) ///< The 'foo' property
+Q_SIGNALS: void clicked(int x, int y); /**< The `clicked` signal */
+public:
+Q_SIGNALS: void activated(); //!< Another signal
+public:
+void doSomething(string arg1, int arg2); /*!< @param arg1 first argument @param arg2 second argument */
+/**
+     * A weirdly documented function.... the inline comment will be stripped. Doxygen would ignore the inline comment anyway.
+     * @param foo first argument
+     * @param bar this argument does exist
+     */
+void weirdlyDocumented(string foo, int bar);
+Q_PROPERTY(string escaped) ///< and an inline comment
+Q_PROPERTY(string block) /**< and an inline comment! ***<  //!<  */
+int square(arg); ///< Compute the arg^2. @return the result
+void refresh(); ///< Inline comment out of place (should be moved inline in the output)
+/*!  Just for fun...
+      ///< Inline comment
+      //!< Inline comment
+      @param arg1 first argument
+      @param arg2 second argument
+      /*!< Inline comment
+    */
+void update(string arg1, int arg2);
+
+Q_PROPERTY(int weirdProperty)
+/* baz */
+/* foo */
+///< and a useless inline comment
+};

--- a/tests/functional/basic/expected/InlineComments.qml.cpp
+++ b/tests/functional/basic/expected/InlineComments.qml.cpp
@@ -24,6 +24,8 @@ Q_PROPERTY(string escaped) ///< and an inline comment
 Q_PROPERTY(string block) /**< and an inline comment! ***<  //!<  */
 int square(arg); ///< Compute the arg^2. @return the result
 void refresh(); ///< Inline comment out of place (should be moved inline in the output)
+// Just some regular comment
+void reload(); ///< Inline comment for a keyword following a regular comment.
 /*!  Just for fun...
       ///< Inline comment
       //!< Inline comment

--- a/tests/functional/basic/input/InlineComments.qml
+++ b/tests/functional/basic/input/InlineComments.qml
@@ -38,6 +38,11 @@ Item {
     function refresh() {
     }
 
+    // Just some regular comment
+
+    function reload() ///< Inline comment for a keyword following a regular comment.
+    {}
+
     /*!  Just for fun...
       ///< Inline comment
       //!< Inline comment

--- a/tests/functional/basic/input/InlineComments.qml
+++ b/tests/functional/basic/input/InlineComments.qml
@@ -1,0 +1,54 @@
+/*
+ * Header bla
+ */
+import QtQuick 1.1
+
+///< What happens here?
+/**
+ * A very simple item   ///< How about here?
+ */
+Item {
+    property int foo  ///< The 'foo' property
+
+    signal clicked(int x, int y)  /**< The `clicked` signal */
+
+    signal activated  //!< Another signal
+
+    function doSomething(arg1, arg2) {   /*!< @param type:string arg1 first argument @param type:int arg2 second argument */
+        console.log("arg1=" + arg1);
+    }
+
+    /**
+     * A weirdly documented function.... the inline comment will be stripped. Doxygen would ignore the inline comment anyway.
+     * @param type:string foo first argument
+     * @param type:int bar this argument does exist
+     */
+    function weirdlyDocumented(foo, bar) {  //!< A weirdly documented function!
+    }
+
+    property string escaped: "a string \n \" \t with escaped chars"  ///< and an inline comment
+    property string block: "a string with some block {({ ] } chars"  /**< and an inline comment! ***<  //!<  */
+
+    function square(arg)    ///< Compute the arg^2. @return type:int the result
+    {
+        return arg * arg;
+    }
+
+    ///< Inline comment out of place (should be moved inline in the output)
+    function refresh() {
+    }
+
+    /*!  Just for fun...
+      ///< Inline comment
+      //!< Inline comment
+      @param type:string arg1 first argument
+      @param type:int arg2 second argument
+      /*!< Inline comment
+    */
+    function update(arg1, arg2) { }
+
+    Item {
+    }
+
+    property /* foo */ int /* bar */ weirdProperty /* baz */ : /* foo */ 12   ///< and a useless inline comment
+}

--- a/tests/unit/qmlclasstestcase.py
+++ b/tests/unit/qmlclasstestcase.py
@@ -81,6 +81,4 @@ class QmlPropertyTestCase(TestCase):
         prop.type = "list<Item>"
         prop.is_default = True
 
-        prop.post_process_doc()
-
-        self.assertEqual(prop.doc, "/// Children\n" + QmlProperty.DEFAULT_PROPERTY_COMMENT)
+        self.assertEqual(str(prop), "/// Children\n" + QmlProperty.DEFAULT_PROPERTY_COMMENT + "\nQ_PROPERTY(list<Item> )")


### PR DESCRIPTION
Doxygen supports some ["inline" comments](https://www.stack.nl/~dimitri/doxygen/manual/docblocks.html#memberdoc) which I'm sometimes fond of using.  Was disappointed to find doxyqml didn't support them... and ended up with this.  Would have been easier to just change my comments, probably, but that's a lot less fun.  :)

I'm not sure it's the most elegant solution, but it's flexible in terms of letting the individual Qml* classes decide how to handle the inlines.  Though the only really custom handling is done for signals (with appending the `public:` thing).  Otherwise it could be handled at a higher level, somewhere in `qmlparser` I imagine. Then it probably wouldn't even have to do [the trick in lexer](https://github.com/mpaperno/doxyqml/blob/inline_comments/doxyqml/lexer.py#L104) with moving the inline comment to before the element.  I really didn't want to refactor too much and went for "minimum disturbance" approach.

Anyway, this does work, and all the existing tests passed (just had to tweak one slightly due to the function change in QmlProperty, but the output is the same).  I can't really come up with any backwards compat. issues, unless perhaps someone has some really badly formatted junk.  I added new tests for the inline types (and fixed some discovered issues... gotta love tests!).

I can tweak things if you'd like, or if this isn't wanted then no worries. (Holding breath that this also passes on Travis... :) )  

Thanks again for the great tool!