### PR TITLE
Add option to not generate "Since: [ver]" in docs

### DIFF
--- a/doxyqml/main.py
+++ b/doxyqml/main.py
@@ -50,6 +50,10 @@ def parse_args(argv):
                         action='append',
                         default=[],
                         help="Wrap the generated C++ classes in NAMESPACE")
+    parser.add_argument("--no-since-version",
+                        action="store_true",
+                        default=False,
+                        help="Don't append \"Since: [version]\" info to docstring")
     parser.add_argument('--version',
                         action='version',
                         version='%%(prog)s %s' % __version__)
@@ -145,6 +149,9 @@ def main(argv=None, out=None):
             print("%20s %s" % (token.type, token.value))
 
     classname, classversion = find_classname(name, namespace)
+    if args.no_since_version:
+        classversion = None
+
     qml_class = QmlClass(classname, classversion)
 
     try:

--- a/tests/functional/no-since-version/args.json
+++ b/tests/functional/no-since-version/args.json
@@ -1,0 +1,1 @@
+["--no-since-version"]

--- a/tests/functional/no-since-version/expected/QualifiedName.qml.cpp
+++ b/tests/functional/no-since-version/expected/QualifiedName.qml.cpp
@@ -1,0 +1,9 @@
+namespace test::doxyqml {
+class QualifiedName : public Item {
+public:
+
+Q_PROPERTY(int x)
+
+Q_PROPERTY(int y)
+};
+}

--- a/tests/functional/no-since-version/input/QualifiedName.qml
+++ b/tests/functional/no-since-version/input/QualifiedName.qml
@@ -1,0 +1,4 @@
+Item {
+    property int x
+    property int y
+}

--- a/tests/functional/no-since-version/input/qmldir
+++ b/tests/functional/no-since-version/input/qmldir
@@ -1,0 +1,2 @@
+module test.doxyqml
+QualifiedName 2.0 QualifiedName.qml


### PR DESCRIPTION
We were not using the version-info in a project at work, so i added an option to not generate them in the first place. Keeping the default to the current behaviour, i thought maybe upstream could want this change as well. 