### PR TITLE
add default parameter support

### DIFF
--- a/doxyqml/qmlclass.py
+++ b/doxyqml/qmlclass.py
@@ -141,6 +141,7 @@ class QmlClass(QmlBaseComponent):
 
 class QmlComponent(QmlBaseComponent):
     """A component inside a QmlClass"""
+
     def __init__(self, name):
         QmlBaseComponent.__init__(self, name)
         self.comment = None
@@ -173,12 +174,19 @@ class QmlArgument(object):
     def __init__(self, name):
         self.type = ""
         self.name = name
+        self.default_value = None
 
     def __str__(self):
         if self.type == "":
-            return self.name
+            return self.name + self.default_value_string()
         else:
-            return self.type + " " + self.name
+            return self.type + " " + self.name + self.default_value_string()
+
+    def default_value_string(self):
+        if self.default_value is None:
+            return ''
+        else:
+            return ' = {}'.format(self.default_value)
 
     def is_public_element(self):
         return True

--- a/doxyqml/qmlparser.py
+++ b/doxyqml/qmlparser.py
@@ -139,9 +139,16 @@ def parse_arguments(reader, typed=False):
             arg.type = arg_type
         else:
             arg = QmlArgument(token.value)
-        args.append(arg)
 
         token = reader.consume_expecting(lexer.CHAR)
+
+        if token.value == "=":
+            token = reader.consume_expecting([lexer.ELEMENT, lexer.STRING])
+            arg.default_value = token.value
+            token = reader.consume_expecting(lexer.CHAR)
+
+        args.append(arg)
+
         if token.value == ")":
             return args
         elif token.value != ",":
@@ -207,12 +214,18 @@ class TokenReader(object):
             if not is_comment_token(token):
                 return token
 
-    def consume_expecting(self, type, value=None):
+    def consume_expecting(self, expected_types, value=None):
         token = self.consume_wo_comments()
-        if token.type != type:
-            raise QmlParserError("Expected token of type '%s', got '%s' instead" % (type, token.type), token)
+        if type(expected_types) is list:
+            if token.type not in expected_types:
+                raise QmlParserError(
+                    "Expected token of type '%s', got '%s' instead" % (expected_types, token.type), token)
+        elif token.type != expected_types:
+            raise QmlParserError(
+                "Expected token of type '%s', got '%s' instead" % (expected_types, token.type), token)
         if value is not None and token.value != value:
-            raise QmlParserError("Expected token with value '%s', got '%s' instead" % (value, token.value), token)
+            raise QmlParserError("Expected token with value '%s', got '%s' instead" % (
+                value, token.value), token)
         return token
 
     def at_end(self):

--- a/tests/functional/basic/expected/FunctionArgs.qml.cpp
+++ b/tests/functional/basic/expected/FunctionArgs.qml.cpp
@@ -37,6 +37,24 @@ Q_PROPERTY(string block)
      * @return the result
      */
 int square(arg);
+/**
+     * Function with int default parameter
+     * @param arg A parameter with a defaultvalue
+     * @return the result
+     */
+int intDefaultParameter(int arg = 0);
+/**
+     * Function with string default parameter
+     * @param arg A parameter with a default value
+     * @return the result
+     */
+string stringDefaultParameter(string arg = "hello");
+/**
+     * Function with property as default parameter
+     * @param arg A parameter with a default value
+     * @return the result
+     */
+int propDefaultParameter(int arg = foo);
 /// One-line comment
 void refresh();
 

--- a/tests/functional/basic/input/FunctionArgs.qml
+++ b/tests/functional/basic/input/FunctionArgs.qml
@@ -45,6 +45,33 @@ Item {
         return arg * arg;
     }
 
+    /**
+     * Function with int default parameter
+     * @param type:int arg A parameter with a defaultvalue
+     * @return type:int the result
+     */
+    function intDefaultParameter(arg = 0) {
+        return arg;
+    }
+
+    /**
+     * Function with string default parameter
+     * @param type:string arg A parameter with a default value
+     * @return type:string the result
+     */
+    function stringDefaultParameter(arg = "hello") {
+        return arg;
+    }
+
+    /**
+     * Function with property as default parameter
+     * @param type:int arg A parameter with a default value
+     * @return type:int the result
+     */
+    function propDefaultParameter(arg = foo) {
+        return arg;
+    }
+
     /// One-line comment
     function refresh() {
     }


### PR DESCRIPTION
Since Qt5.12, Qt QML module supports ECMAScript 7 (https://doc.qt.io/qt-5/whatsnew512.html).  This includes an upgrade to ECMAScript 6 which includes handling of default parameters values (http://es6-features.org/#DefaultParameterValues).

The goal of this pull request is to fix the error raised by doxyqml when parsing QML with default parameters values.